### PR TITLE
조직도 히스토리 추가

### DIFF
--- a/company/models.py
+++ b/company/models.py
@@ -9,6 +9,9 @@ class Corporation(models.Model):
     hr_team = models.ForeignKey('company.Team', related_name='corporation_hr_team', on_delete=models.SET_NULL, null=True)
     #hr_team_members = models.ManyToManyField('person.Person', related_name='hr_team_members', blank=True)
 
+    name_history = models.JSONField(default=list, blank=True)
+    last_commit = models.ForeignKey('company.Commit', related_name='corporation_last_commit', on_delete=models.SET_NULL, null=True, blank=True)
+
     class Meta:
         db_table = 'corporation'
 
@@ -16,6 +19,7 @@ class Corporation(models.Model):
 class Team(models.Model):
     t_id = models.BigAutoField(primary_key=True)
     name = models.CharField(max_length=255)
+    is_active = models.BooleanField(default=True)
 
     corporation = models.ForeignKey(Corporation, related_name='teams', on_delete=models.CASCADE, null=True, blank=True)
 
@@ -26,5 +30,20 @@ class Team(models.Model):
     members = models.ManyToManyField('person.Person', related_name='member_of_teams', blank=True)
     team_leader = models.ForeignKey('person.Person', related_name='leading_teams', on_delete=models.SET_NULL, null=True, blank=True)
 
+    parent_team_history = models.JSONField(default=list, blank=True)
+    last_commit = models.ForeignKey('company.Commit', related_name='team_last_commit', on_delete=models.SET_NULL, null=True, blank=True)
+
+    name_history = models.JSONField(default=list, blank=True)
+
     class Meta:
         db_table = 'team'
+
+class Commit(models.Model):
+    commit_id = models.BigAutoField(primary_key=True)
+    commit_message = models.TextField()
+    commit_date = models.DateTimeField(auto_now_add=True)
+    commit_author = models.ForeignKey('person.Person', related_name='commits', on_delete=models.SET_NULL, null=True, blank=True)
+    commit_content = models.JSONField(default=list, blank=True)
+
+    class Meta:
+        db_table = 'commit'

--- a/company/paginations.py
+++ b/company/paginations.py
@@ -10,3 +10,7 @@ class CorpListPagination(CursorPagination):
 class TeamListPagination(CursorPagination):
     page_size = 10
     ordering = 't_id'
+
+class CommitListPagination(CursorPagination):
+    page_size = 10
+    ordering = 'commit_id'

--- a/company/serializers.py
+++ b/company/serializers.py
@@ -82,3 +82,8 @@ class TeamUpdateDeleteSerializer(serializers.ModelSerializer):
         model = Team
         fields = ['t_id', 'name', 'corporation', 'sub_teams', 'parent_teams', 'members', 'team_leader']
         read_only_fields = ['t_id']
+
+class CommitListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Commit
+        fields = ['commit_id', 'commit_message', 'commit_date', 'commit_author', 'commit_content']

--- a/company/serializers.py
+++ b/company/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Corporation, Team
+from .models import Corporation, Team, Commit
 from person.models import Person
 
 
@@ -70,12 +70,15 @@ class TeamDetailSerializer(serializers.ModelSerializer):
 
 
 class TeamCreateSerializer(serializers.ModelSerializer):
+    parent_team_history = serializers.ListField(default=list)
+    name_history = serializers.ListField(default=list)
     class Meta:
         model = Team
-        fields = ['name', 'corporation', 'sub_teams', 'parent_teams', 'members', 'team_leader']
-
+        fields = ['t_id', 'name', 'corporation', 'sub_teams', 'parent_teams', 'members', 'team_leader', 'parent_team_history', 'name_history', 'last_commit']
+        read_only_fields = ['t_id']
 
 class TeamUpdateDeleteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Team
-        fields = ['name', 'corporation', 'sub_teams', 'parent_teams', 'members', 'team_leader']
+        fields = ['t_id', 'name', 'corporation', 'sub_teams', 'parent_teams', 'members', 'team_leader']
+        read_only_fields = ['t_id']

--- a/company/urls.py
+++ b/company/urls.py
@@ -5,15 +5,19 @@ from .views import *
 urlpatterns = [
     # Corporation
     path('corp/list/', CorpListAPIView.as_view(), name='corp-list'),  # list all corporations
-    path('corp/<int:c_id>/update/', CorpUpdateDeleteAPIView.as_view(), name='corp-update'),  # update corporation info
-    path('corp/<int:c_id>/delete/', CorpUpdateDeleteAPIView.as_view(), name='corp-delete'),  # delete corporation info
+    #path('corp/<int:c_id>/update/', CorpUpdateDeleteAPIView.as_view(), name='corp-update'),  # update corporation info
+    #path('corp/<int:c_id>/delete/', CorpUpdateDeleteAPIView.as_view(), name='corp-delete'),  # delete corporation info
     path('corp/<int:c_id>/', CorpDetailAPIView.as_view(), name='corp-detail'),  # get specific corporation info
-    path('corp/create/', CorpCreateAPIView.as_view(), name='corp-create'),  # create new corporation
+    #path('corp/create/', CorpCreateAPIView.as_view(), name='corp-create'),  # create new corporation
+    path('corp/commit/', CorpBatchProcessView.as_view(), name='corp-commit'), # use commit for create/delete/update corp
+    path('corp/<int:c_id>/', GetCorpOfCommitView.as_view(), name='corp-of-commit'),
 
     # Team
     path('team/list/', TeamListAPIView.as_view(), name='team-list'),  # list all teams
-    path('team/<int:t_id>/update/', TeamUpdateDeleteAPIView.as_view(), name='team-update'),  # update team info
-    path('team/<int:t_id>/delete/', TeamUpdateDeleteAPIView.as_view(), name='team-delete'),  # delete team info
+    #path('team/<int:t_id>/update/', TeamUpdateDeleteAPIView.as_view(), name='team-update'),  # update team info
+    #path('team/<int:t_id>/delete/', TeamUpdateDeleteAPIView.as_view(), name='team-delete'),  # delete team info
     path('team/<int:t_id>/', TeamDetailAPIView.as_view(), name='team-detail'),  # get specific team info
-    path('team/create/', TeamCreateAPIView.as_view(), name='team-create'),  # create new team
+    #path('team/create/', TeamCreateAPIView.as_view(), name='team-create'),  # create new team
+    path('team/commit/', TeamBatchProcessView.as_view(), name='team-commit'), # use commit for create/delete/update team
+    path('team/<int:t_id>/old/', GetTeamOfCommitView.as_view(), name='team-of-commit'),
 ]

--- a/company/urls.py
+++ b/company/urls.py
@@ -20,4 +20,7 @@ urlpatterns = [
     #path('team/create/', TeamCreateAPIView.as_view(), name='team-create'),  # create new team
     path('team/commit/', TeamBatchProcessView.as_view(), name='team-commit'), # use commit for create/delete/update team
     path('team/<int:t_id>/old/', GetTeamOfCommitView.as_view(), name='team-of-commit'),
+
+    # Commit
+    path('commit/list/', CommitListAPIView.as_view(), name='commit-list'),  # list all commits
 ]

--- a/company/views.py
+++ b/company/views.py
@@ -277,7 +277,7 @@ class CorpBatchProcessView(APIView):
             except Exception as e:
                 errors.append({"item": item, "error": str(e)})
 
-        return Response({"results": results, "errors": errors}, status=200)
+        return Response({"results": results, "errors": errors, "commit_id": new_commit.commit_id}, status=200)
 
 class GetCorpOfCommitView(APIView):
     def get(self, request, *args, **kwargs):

--- a/company/views.py
+++ b/company/views.py
@@ -1,10 +1,19 @@
+from django.db.models import Subquery, OuterRef
+from django.db.models.signals import post_save, post_delete, m2m_changed
+from django.dispatch import receiver
 from django.shortcuts import get_object_or_404
 from rest_framework.generics import ListAPIView, CreateAPIView, RetrieveAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework.exceptions import ValidationError
 from .serializers import *
 from .paginations import *
 from rest_framework import status
+from django.db.models import OuterRef, Subquery
+import logging
 
+logger = logging.getLogger(__name__)
 
 # Corporation
 class CorpListAPIView(ListAPIView):
@@ -69,7 +78,7 @@ class TeamListAPIView(ListAPIView):
     def get_queryset(self):
         name = self.request.query_params.get('name')
         if not name:
-            return Team.objects.all()
+            return Team.objects.filter(is_active=True)
         return Team.objects.filter(name__icontains=name)
 
 
@@ -112,5 +121,209 @@ class TeamUpdateDeleteAPIView(RetrieveUpdateDestroyAPIView):
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
-        self.perform_destroy(instance)
+        instance.is_active = False
+        instance.save()
         return Response(status=204)
+
+@receiver(post_save, sender=Corporation)
+@receiver(post_save, sender=Team)
+def update_name_history_on_save(sender, instance, **kwargs):
+    if getattr(instance, '_disable_signal', False):
+        return
+
+    if instance.name_history is None:
+        instance.name_history = []
+
+    updated_name_history = instance.name_history + [{
+        'name': instance.name,
+        'commit_id': instance.last_commit.commit_id,
+    }]
+    instance.name_history = updated_name_history
+
+    instance._disable_signal = True
+    try:
+        instance.save(update_fields=["name_history"])
+    finally:
+        instance._disable_signal = False
+
+@receiver(m2m_changed, sender=Team.parent_teams.through)
+def update_parent_team_history_on_m2m_change(sender, instance, action, **kwargs):
+    if action != "post_add":
+        return
+
+    logger.critical(f"Parent team change detected for Team {instance.t_id}: {action}")
+
+    parent_team_id = instance.parent_teams.first().t_id if instance.parent_teams.exists() else ""
+
+    if instance.parent_team_history is None:
+        instance.parent_team_history = []
+
+    updated_parent_history = instance.parent_team_history + [{
+        'parent_id': parent_team_id,
+        'commit_id': instance.last_commit.commit_id,
+    }]
+    instance.parent_team_history = updated_parent_history
+
+    logger.critical(f"Parent team history updated: {updated_parent_history}")
+
+    instance._disable_signal = True
+    try:
+        instance.save(update_fields=["parent_team_history"])
+    finally:
+        instance._disable_signal = False
+
+
+
+class TeamBatchProcessView(APIView):
+    parser_classes = [JSONParser]
+
+    def post(self, request, *args, **kwargs):
+        if request.data.get('add_commit', True):
+            new_commit = Commit.objects.create(
+                commit_message=request.data.get('commit_message'),
+                commit_author=request.user.person
+            )
+        else:
+            new_commit = Commit.objects.last()
+        new_commit.commit_content.extend(request.data.get('updates', []))
+        new_commit.save()
+
+        results = {"created": [], "updated": [], "deleted": []}
+        errors = []
+
+        for item in request.data.get('updates', []):
+            t_id = item.get('t_id')
+            request_type = item.get('request_type')
+
+            try:
+                if request_type == 'delete':
+                    instance = Team.objects.get(t_id=t_id)
+                    instance.is_active = False
+                    instance.last_commit = new_commit
+                    instance.save()
+                    results["deleted"].append({"t_id": t_id})
+
+                elif request_type == 'update':
+                    instance = Team.objects.get(t_id=t_id)
+                    serializer = TeamUpdateDeleteSerializer(
+                        instance, data=item, partial=True
+                    )
+                    serializer.is_valid(raise_exception=True)
+                    serializer.save(last_commit=new_commit)
+                    results["updated"].append(serializer.data)
+
+                elif request_type == 'create':
+                    serializer = TeamCreateSerializer(data=item)
+                    serializer.is_valid(raise_exception=True)
+                    serializer.save(last_commit=new_commit)
+                    results["created"].append(serializer.data)
+
+                else:
+                    raise ValidationError(f"Invalid request type: {request_type}")
+
+            except Exception as e:
+                errors.append({"item": item, "error": str(e)})
+
+        return Response({"results": results, "errors": errors}, status=200)
+
+
+class CorpBatchProcessView(APIView):
+    parser_classes = [JSONParser]
+
+    def post(self, request, *args, **kwargs):
+        if request.data.get('add_commit', True):
+            new_commit = Commit.objects.create(
+                commit_message=request.data.get('commit_message'),
+                commit_author=request.user.person
+            )
+        else:
+            new_commit = Commit.objects.last()
+        new_commit.commit_content.extend(request.data.get('updates', []))
+        new_commit.save()
+
+        results = {"created": [], "updated": [], "deleted": []}
+        errors = []
+
+        for item in request.data.get('updates', []):
+            c_id = item.get('c_id')
+            request_type = item.get('request_type')
+
+            try:
+                if request_type == 'delete':
+                    instance = Corporation.objects.get(c_id=c_id)
+                    instance.is_active = False
+                    instance.last_commit = new_commit
+                    instance.save()
+                    results["deleted"].append({"c_id": c_id})
+
+                elif request_type == 'update':
+                    instance = Corporation.objects.get(c_id=c_id)
+                    serializer = CorpUpdateDeleteSerializer(
+                        instance, data=item, partial=True
+                    )
+                    serializer.is_valid(raise_exception=True)
+                    serializer.save(last_commit=new_commit)
+                    results["updated"].append(serializer.data)
+
+                elif request_type == 'create':
+                    serializer = CorpCreateSerializer(data=item)
+                    serializer.is_valid(raise_exception=True)
+                    serializer.save(last_commit=new_commit)
+                    results["created"].append(serializer.data)
+
+                else:
+                    raise ValidationError(f"Invalid request type: {request_type}")
+
+            except Exception as e:
+                errors.append({"item": item, "error": str(e)})
+
+        return Response({"results": results, "errors": errors}, status=200)
+
+class GetCorpOfCommitView(APIView):
+    def get(self, request, *args, **kwargs):
+        target_corp_id = kwargs.get('c_id')
+        target_commit_id = request.query_params.get('commit')
+        teams = Team.objects.filter(corporation__c_id=target_corp_id)
+        children = []
+
+        for sub_team_candidate in teams:
+            for d in sub_team_candidate.parent_team_history[::-1]:
+                if d.get('commit_id') <= int(target_commit_id):
+                    if  d.get('parent_id') == '':
+                        children.append(sub_team_candidate.t_id)
+                    break
+
+        corporation = Corporation.objects.get(c_id=target_corp_id)
+        serializer = CorpDetailSerializer(corporation)
+        response_data = serializer.data.copy()
+
+        for n in corporation.name_history:
+            if n.get('commit_id') <= int(target_commit_id):
+                response_data.update({"name": n.get('name')})
+        response_data.update({"sub_teams": children})
+        return Response(response_data, status=200)
+
+class GetTeamOfCommitView(APIView):
+    def get(self, request, *args, **kwargs):
+        target_team_id = kwargs.get('t_id')
+        target_commit_id = request.query_params.get('commit')
+        teams = Team.objects.all()
+        children = []
+
+        for sub_team_candidate in teams:
+            for d in sub_team_candidate.parent_team_history[::-1]:
+                if d.get('commit_id') <= int(target_commit_id):
+                    if  d.get('parent_id') == int(target_team_id):
+                        children.append(sub_team_candidate.t_id)
+                    break
+
+        team = Team.objects.get(t_id=target_team_id)
+        serializer = TeamDetailSerializer(team)
+        response_data = serializer.data.copy()
+
+        for n in team.name_history:
+            if n.get('commit_id') <= int(target_commit_id):
+                response_data.update({"name": n.get('name')})
+        response_data.update({"sub_teams": children})
+        return Response(response_data, status=200)
+

--- a/company/views.py
+++ b/company/views.py
@@ -327,3 +327,7 @@ class GetTeamOfCommitView(APIView):
         response_data.update({"sub_teams": children})
         return Response(response_data, status=200)
 
+class CommitListAPIView(ListAPIView):
+    serializer_class = CommitListSerializer
+    pagination_class = CommitListPagination
+    queryset = Commit.objects.all()


### PR DESCRIPTION
`/team/commit/` 은 다음과 같은 형식으로 보내게 만들었습니다
```
{
  "commit_message": "test commit 6",
  "add_commit": "true",
  "updates": [
    {
      "request_type": "create",
      "name": "team x",
      "corporation": 1,
      "sub_teams": [],
      "parent_teams": [1],
      "members": [6, 7],
      "team_leader": 1
    },
    {
      "request_type": "update",
      "t_id": 4,
      "name": "team y"
      "parent_teams": [1]
    },
    {
      "request_type": "delete",
      "t_id": 3,
      "name": "team y"
      "parent_teams": [1]
    },
  ]
}
```

`/team/<t_id>/old/?commit=<commit_id>` 를 통해 특정 커밋에서의 team 조회가 가능합니다.

만약 commit을 할 때, 여러 번으로 나누어야 할 경우 (새 팀 아래 또다시 새 팀을 만들때, t_id를 한번에 알수 없으므로) add_commit을 처음 요청에만 true로 하고 나중에 false로 하면 같은 커밋에 변경사항이 속하게 됩니다

corporation에 대해서도 이름 변경 기록만 추적한다는 것 외에는 동일합니다